### PR TITLE
fix(ATen): honor deterministic algorithms in embedding backward

### DIFF
--- a/tests/unittest/operator/test_embedding.py
+++ b/tests/unittest/operator/test_embedding.py
@@ -213,6 +213,46 @@ def test_embedding_bwd(dtype, scale_grad_by_freq, input_shape, fixed_indices):
             assert not comparator(scaled_result.float(), unscaled_result.float())
 
 
+@pytest.mark.skipif(
+    testing.get_musa_arch() < 22,
+    reason="bf16 is not supported on arch older than qy2",
+)
+@testing.test_on_nonzero_card_if_multiple_musa_device(1)
+def test_embedding_dense_backward_deterministic_algorithms():
+    indices = torch.tensor(
+        [0] * 133 + [1 + (position % 156) for position in range(2063 - 133)],
+        dtype=torch.int64,
+        device="musa",
+    )
+    positions = torch.arange(2063 * 128, dtype=torch.float32).reshape(2063, 128)
+    grad = (
+        torch.sin(positions * 0.00037) * 0.125
+        + torch.cos(positions * 0.00011) * 0.0625
+    ).to(device="musa", dtype=torch.bfloat16)
+
+    deterministic_algorithms_enabled = (
+        torch.are_deterministic_algorithms_enabled()
+    )
+    deterministic_algorithms_warn_only_enabled = (
+        torch.is_deterministic_algorithms_warn_only_enabled()
+    )
+    try:
+        torch.use_deterministic_algorithms(True)
+        outputs = [
+            torch.ops.aten.embedding_dense_backward(
+                grad, indices, 512, -1, False
+            ).cpu()
+            for _ in range(8)
+        ]
+    finally:
+        torch.use_deterministic_algorithms(
+            deterministic_algorithms_enabled,
+            warn_only=deterministic_algorithms_warn_only_enabled,
+        )
+
+    assert all(torch.equal(outputs[0], output) for output in outputs[1:])
+
+
 float_dtypes = [torch.float32]
 
 

--- a/tests/unittest/operator/test_embedding.py
+++ b/tests/unittest/operator/test_embedding.py
@@ -253,6 +253,32 @@ def test_embedding_dense_backward_deterministic_algorithms():
     assert all(torch.equal(outputs[0], output) for output in outputs[1:])
 
 
+@testing.test_on_nonzero_card_if_multiple_musa_device(1)
+def test_embedding_dense_backward_deterministic_algorithms_empty_indices():
+    indices = torch.empty((0,), dtype=torch.int64, device="musa")
+    grad = torch.empty((0, 128), dtype=torch.float32, device="musa")
+
+    deterministic_algorithms_enabled = (
+        torch.are_deterministic_algorithms_enabled()
+    )
+    deterministic_algorithms_warn_only_enabled = (
+        torch.is_deterministic_algorithms_warn_only_enabled()
+    )
+    try:
+        torch.use_deterministic_algorithms(True)
+        output = torch.ops.aten.embedding_dense_backward(
+            grad, indices, 512, -1, False
+        )
+    finally:
+        torch.use_deterministic_algorithms(
+            deterministic_algorithms_enabled,
+            warn_only=deterministic_algorithms_warn_only_enabled,
+        )
+
+    assert output.shape == (512, 128)
+    assert torch.count_nonzero(output).item() == 0
+
+
 float_dtypes = [torch.float32]
 
 

--- a/torch_musa/csrc/aten/ops/musa/Embedding.mu
+++ b/torch_musa/csrc/aten/ops/musa/Embedding.mu
@@ -1,4 +1,5 @@
 #include <ATen/ATen.h>
+#include <ATen/Context.h>
 #include <ATen/Dispatch.h>
 #include <ATen/ceil_div.h>
 #include <ATen/core/Tensor.h>
@@ -72,7 +73,8 @@ Tensor EmbeddingDenseBwdMUSA(
 
   // be careful for setting this value, there may be
   // precision and efficiency drops when value gets larger.
-  if (num_indices <= 3072 && !scale_grad_by_freq) {
+  if (num_indices <= 3072 && !scale_grad_by_freq &&
+      !at::globalContext().deterministicAlgorithms()) {
     Tensor grad_weight = at::zeros(
         {num_weights, grad_output.size(-1)},
         grad_output.options().memory_format(at::MemoryFormat::Contiguous));

--- a/torch_musa/csrc/aten/ops/musa/EmbeddingBackwardKernel.mu
+++ b/torch_musa/csrc/aten/ops/musa/EmbeddingBackwardKernel.mu
@@ -316,6 +316,10 @@ Tensor EmbeddingBackwardMUSAKernel(
   const ptrdiff_t numel = sorted_indices.numel();
   Tensor grad_weight = at::zeros({num_weights, grad.size(-1)}, grad.options());
 
+  if (C10_UNLIKELY(numel == 0)) {
+    return grad_weight;
+  }
+
   int tbl_h = grad_weight.size(0);
   int tbl_w = grad_weight.size(1);
 


### PR DESCRIPTION
## Summary

The short-indices fast path in `EmbeddingDenseBwdMUSA` accumulates repeated
embedding IDs with atomic additions. The path is selected for
`num_indices <= 3072` when `scale_grad_by_freq` is disabled, even when the user
has enabled deterministic algorithms.

This change keeps the atomic fast path as the default, but bypasses it when
`at::globalContext().deterministicAlgorithms()` is true. Deterministic mode then
reuses the existing sorted/segmented implementation.

## User-visible behavior

- `torch.use_deterministic_algorithms(False)`: unchanged; eligible calls still
  use the atomic fast path.
- `torch.use_deterministic_algorithms(True)`: repeated calls with identical
  inputs use the existing deterministic sorted/segmented path.
- Forward behavior and the mathematical definition of the gradient are
  unchanged.

This follows PyTorch's deterministic-algorithm policy: a nondeterministic
atomic optimization should not be selected when deterministic algorithms are
requested. PyTorch's CUDA short-index dense embedding kernel explicitly
serializes duplicate-ID accumulation instead of using unordered atomic adds.

## Regression test

The new test uses 2,063 BF16 indices with repeated IDs, deliberately remaining
below the 3,072-element fast-path threshold. It enables deterministic
algorithms, evaluates `aten::embedding_dense_backward` eight times, checks
bitwise equality, and restores the caller's original global deterministic
and warn-only state in a `finally` block.

## Device validation

The issue and the proposed routing guard were tested on:

- device: MTT S4000 48 GB;
- Python 3.10.8;
- PyTorch 2.2.0;
- public source baseline: torch_musa v1.3.0;
- isolated patched wheel version: `torch_musa 1.3.0+3d6a817`.

Observed with eight fresh processes per mode:

| Mode | Unique output hashes |
| --- | ---: |
| Native atomic path, deterministic mode off | 8 |
| Patched deterministic mode | 1 |
| Existing sorted-path padding workaround | 1 |

The patched deterministic result exactly matched the sorted-path workaround.
The focused regression test failed on the installed unpatched wheel and passed
on the isolated patched wheel (`1 passed`).

For this synthetic operator shape, after 25 warm-up calls and 200 synchronized
samples, median latency was 0.9701 ms for the native atomic path and 1.0233 ms
for the patched deterministic path (1.055x). This is an operator microbenchmark,
not an end-to-end training throughput claim. Default-mode routing is unchanged.

## Validation boundary

The device validation above was performed against the v1.3-era runtime, not the
current `main` runtime. The installed vendor wheel reported a private commit
that is not present in the public Git history, so the validation wheel was
built from the public v1.3.0 tag with an ABI-compatible reconstruction using the
installed operator schema and applicable compatibility patches. It validates
the fix mechanism on the stated S4000 environment, but is not a bit-for-bit
reproduction of that private vendor build.

This PR is a static, minimal adaptation of the same guard to current `main` at
base commit `246d43e3525a9102162cbebfb25c067d634d95a2`. Maintainer CI should run
the added test on the current supported MUSA devices and runtime before merge.

## Test plan

- [x] `git diff --check`
- [x] Python syntax check for `tests/unittest/operator/test_embedding.py`
- [x] Focused regression test on the isolated v1.3 patched wheel: `1 passed`
- [x] Eight-process S4000 reproducer: deterministic mode changed from multiple
      hashes to one hash
- [ ] Current-main MUSA CI / device test (maintainer environment required)

## References

- Public reproducer, measurements, and v1.3 patch:
  <https://github.com/Hldao/musa-embedding-determinism>
- [PyTorch deterministic algorithms API][pytorch-determinism]
- PyTorch CUDA embedding implementation:
  <https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu>

[pytorch-determinism]: https://docs.pytorch.org/docs/stable/generated/torch.use_deterministic_algorithms.html

## Contributor

Prepared by WKK AI R&D, the public-facing brand of
哇咔咔人工智能技术研发有限公司.
